### PR TITLE
Add documentation tabs for datasets, models and metrics

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 .jekyll-cache
 .gem
 .bundle
+vendor/

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -69,6 +69,12 @@ main:
       url: /compatibility/#lidar-semantic-segmentation
     - title: "Image object detection"
       url: /compatibility/#image-object-detection
+  - title: Datasets
+    url: /datasets
+  - title: Models
+    url: /models
+  - title: Metrics
+    url: /metrics
   - title: Usage
     url: /usage
     children:

--- a/docs/_pages/datasets.md
+++ b/docs/_pages/datasets.md
@@ -1,0 +1,228 @@
+---
+layout: home
+title: Datasets
+permalink: /datasets/
+
+sidebar:
+  nav: "main"
+---
+
+This page summarizes the dataset adapters available in PerceptionMetrics and the inputs each adapter expects. Dataset adapters normalize different dataset layouts into the common `PerceptionDataset` abstractions used by model evaluation, prediction evaluation, the GUI, and the Python API.
+
+## Support Matrix
+
+| Dataset adapter | Task | Modality | CLI format | Status |
+| --- | --- | --- | --- | --- |
+| GAIA | Segmentation | Image, LiDAR | `gaia` | CLI and library |
+| Generic | Segmentation | Image, LiDAR | `generic` | CLI and library |
+| GOOSE | Segmentation | Image, LiDAR | `goose` | CLI and library |
+| RELLIS-3D | Segmentation | Image, LiDAR | `rellis3d` | CLI and library |
+| RUGD | Segmentation | Image | `rugd` | CLI and library |
+| WildScenes | Segmentation | Image, LiDAR | `wildscenes` | Library adapter |
+| Cityscapes | Segmentation | Image | `cityscapes` | Library adapter |
+| COCO | Object detection | Image | `coco` | CLI and library |
+| YOLO | Object detection | Image | `yolo` | Library adapter |
+| nuImages | Segmentation, object detection | Image | `nuimages` | Library adapter |
+
+The CLI currently constructs datasets through `perceptionmetrics.cli.get_dataset`. If a dataset appears in the library registry but is not handled by that CLI helper, use it from Python until CLI wiring is added.
+
+## Common Concepts
+
+All segmentation datasets expose samples with a data file, label file, and split. Image segmentation datasets use image masks as labels; LiDAR segmentation datasets use point labels. Object detection datasets expose image files and annotations that can be converted into bounding boxes and class indices.
+
+Most segmentation adapters need an ontology. The common ontology shape is:
+
+```json
+{
+  "road": {
+    "idx": 0,
+    "rgb": [128, 64, 128]
+  },
+  "vegetation": {
+    "idx": 1,
+    "rgb": [107, 142, 35]
+  }
+}
+```
+
+Some adapters build the ontology from the official dataset metadata. For others, you need to provide an ontology file. The ontology file can be in JSON or YAML format, and the exact expected shape depends on the adapter. 
+
+
+
+## GAIA
+
+GAIA is a custom PerceptionMetrics format backed by a Parquet file. The Parquet file is loaded with Pandas, and paths are resolved relative to the directory containing that Parquet file.
+
+Expected inputs:
+
+- `--dataset_fname /path/to/dataset.parquet`
+- An ontology file in the same directory, named `ontology.json` by default
+- Optionally, a Parquet attribute named `ontology_fname` pointing to a different ontology filename
+
+Typical columns:
+
+| Modality | Required columns |
+| --- | --- |
+| Image segmentation | `image`, `label`, `split` |
+| LiDAR segmentation | `points`, `label`, `split` |
+
+## Generic
+
+Generic datasets are useful when files can be paired by matching wildcard captures in input and label patterns. They support image and LiDAR segmentation.
+
+Expected inputs:
+
+- At least one of `--train_dataset_dir`, `--val_dataset_dir`, or `--test_dataset_dir`
+- `--data_suffix`
+- `--label_suffix`
+- `--dataset_ontology`
+
+The data and label suffixes must contain the same number of `*` wildcards. For example:
+
+```shell
+--data_suffix "*_image.png" --label_suffix "*_label.png"
+```
+
+The ontology may be either a list of class names:
+
+```json
+["background", "road", "vegetation"]
+```
+
+or a dictionary:
+
+```json
+{
+  "background": {"idx": 0, "rgb": [0, 0, 0]},
+  "road": {"idx": 1, "rgb": [128, 64, 128]}
+}
+```
+
+## GOOSE
+
+GOOSE supports image and LiDAR semantic segmentation. The adapter expects the official split directory layout and reads `goose_label_mapping.csv` from the first provided split root.
+
+Expected inputs:
+
+- One or more of `--train_dataset_dir`, `--val_dataset_dir`, `--test_dataset_dir`
+- Each split root should contain `goose_label_mapping.csv`
+- Image data under `images/<split>/*/*_windshield_vis.png`
+- Image labels under `labels/<split>/<scene>/*_labelids.png`
+- LiDAR data under `lidar/<split>/*/*_vls128.bin` for GOOSE or `*_pcl.bin` for GOOSE Ex
+- LiDAR labels under `labels/<split>/<scene>/*_goose.label`
+
+## RELLIS-3D
+
+RELLIS-3D supports image and LiDAR semantic segmentation. The adapter uses official `.lst` split files and a YAML ontology file.
+
+Expected inputs:
+
+- `--dataset_dir`: directory containing the extracted data and labels
+- `--split_dir`: directory containing split files
+- `--dataset_ontology`: RELLIS-3D ontology YAML
+
+Image split files:
+
+- `train.lst`
+- `val.lst`
+- `test.lst`
+
+LiDAR split files:
+
+- `pt_train.lst`
+- `pt_val.lst`
+- `pt_test.lst`
+
+Each row in a split file is expected to contain the relative data path and relative label path separated by a space.
+
+## RUGD
+
+RUGD supports image semantic segmentation. Labels are RGB masks, so the adapter initializes the base image segmentation dataset with RGB-label handling enabled.
+
+Expected inputs:
+
+- `--images_dir`
+- `--labels_dir`
+- `--dataset_ontology`, usually `RUGD_annotation-colormap.txt`
+
+The default train, validation, and test split assignment is built into the adapter using the sequence names from the RUGD paper.
+
+## WildScenes
+
+WildScenes supports image and LiDAR semantic segmentation through library adapters. The adapters expect official CSV split files and use ontology definitions embedded in the adapter source.
+
+Expected inputs in Python:
+
+- `dataset_dir`: root of the WildScenes data
+- `split_dir`: directory containing `train.csv`, `val.csv`, and `test.csv`
+
+Use the 2D split files for `WildscenesImageSegmentationDataset` and the 3D split files for `WildscenesLiDARSegmentationDataset`.
+
+## Cityscapes
+
+Cityscapes supports image semantic segmentation through the Python API.
+
+Expected inputs in Python:
+
+- One or more of `train_dataset_root`, `val_dataset_root`, `test_dataset_root`
+- Images under `leftImg8bit_trainvaltest/leftImg8bit/<split>/<city>/`
+- Labels under `gtFine/<split>/<city>/`
+- Default image suffix: `_leftImg8bit.png`
+- Default label suffix: `_gtFine_labelIds.png`
+
+The adapter can build either Cityscapes label-id ontologies or train-id ontologies. When using train IDs, provide train-id labels with `label_suffix="_gtFine_labelTrainIds.png"`.
+
+## COCO
+
+COCO supports image object detection and is available from the CLI and Python API.
+
+Expected layout:
+
+```text
+dataset_root/
+  images/
+    train2017/
+    val2017/
+  annotations/
+    instances_train2017.json
+    instances_val2017.json
+```
+
+Expected CLI inputs:
+
+- `--dataset_format coco`
+- `--dataset_dir /path/to/dataset_root`
+- `--split train` or `--split val`
+
+The CLI currently supports one COCO split at a time. The adapter looks for an image directory matching the split name, such as `val2017`, and an annotation file matching `instances_<split>*.json`.
+
+## YOLO
+
+YOLO supports image object detection through the Python API. The adapter reads an Ultralytics-style dataset YAML file.
+
+Expected YAML fields:
+
+```yaml
+path: /path/to/dataset
+train: images/train
+val: images/val
+test: images/test
+names:
+  0: person
+  1: vehicle
+```
+
+The adapter expects labels in matching `labels/<split>` directories and converts YOLO normalized center-width-height boxes into absolute `[x1, y1, x2, y2]` boxes.
+
+## nuImages
+
+nuImages supports image object detection and image semantic segmentation through the Python API.
+
+Expected inputs in Python:
+
+- `dataset_dir`: nuImages root directory
+- `version`, defaulting to `v1.0-mini`
+- `split`, defaulting to `train`
+
+
+

--- a/docs/_pages/datasets.md
+++ b/docs/_pages/datasets.md
@@ -15,16 +15,17 @@ This page summarizes the dataset adapters available in PerceptionMetrics and the
 | --- | --- | --- | --- | --- |
 | GAIA | Segmentation | Image, LiDAR | `gaia` | CLI and library |
 | Generic | Segmentation | Image, LiDAR | `generic` | CLI and library |
-| GOOSE | Segmentation | Image, LiDAR | `goose` | CLI and library |
-| RELLIS-3D | Segmentation | Image, LiDAR | `rellis3d` | CLI and library |
-| RUGD | Segmentation | Image | `rugd` | CLI and library |
-| WildScenes | Segmentation | Image, LiDAR | `wildscenes` | Library adapter |
-| Cityscapes | Segmentation | Image | `cityscapes` | Library adapter |
-| COCO | Object detection | Image | `coco` | CLI and library |
-| YOLO | Object detection | Image | `yolo` | Library adapter |
-| nuImages | Segmentation, object detection | Image | `nuimages` | Library adapter |
+| [GOOSE](https://goose-dataset.de/) | Segmentation | Image, LiDAR | `goose` | CLI and library |
+| [RELLIS-3D](https://github.com/unmannedlab/RELLIS-3D) | Segmentation | Image, LiDAR | `rellis3d` | CLI and library |
+| [RUGD](http://rugd.vision/) | Segmentation | Image | `rugd` | CLI and library |
+| [WildScenes](https://github.com/csiro-robotics/WildScenes) | Segmentation | Image, LiDAR | `wildscenes` | CLI and library |
+| [Cityscapes](https://www.cityscapes-dataset.com/) | Segmentation | Image | `cityscapes` | CLI and library |
+| [SemanticKITTI](https://semantic-kitti.org/) | Segmentation | LiDAR | `semantickitti_lidar_segmentation` | CLI and library |
+| [COCO](https://cocodataset.org/#home) | Object detection | Image | `coco` | CLI and library |
+| [YOLO](https://docs.ultralytics.com/datasets/detect/) | Object detection | Image | `yolo` | CLI and library |
+| [nuImages](https://www.nuscenes.org/nuimages) | Segmentation, object detection | Image | `nuimages` | CLI and library |
 
-The CLI currently constructs datasets through `perceptionmetrics.cli.get_dataset`. If a dataset appears in the library registry but is not handled by that CLI helper, use it from Python until CLI wiring is added.
+The CLI constructs datasets through `perceptionmetrics.cli.get_dataset`, while the same adapters can also be used directly from Python.
 
 ## Common Concepts
 
@@ -149,9 +150,9 @@ The default train, validation, and test split assignment is built into the adapt
 
 ## WildScenes
 
-WildScenes supports image and LiDAR semantic segmentation through library adapters. The adapters expect official CSV split files and use ontology definitions embedded in the adapter source.
+WildScenes supports image and LiDAR semantic segmentation through the CLI and Python API. The adapters expect official CSV split files and use ontology definitions embedded in the adapter source.
 
-Expected inputs in Python:
+Expected inputs:
 
 - `dataset_dir`: root of the WildScenes data
 - `split_dir`: directory containing `train.csv`, `val.csv`, and `test.csv`
@@ -160,9 +161,9 @@ Use the 2D split files for `WildscenesImageSegmentationDataset` and the 3D split
 
 ## Cityscapes
 
-Cityscapes supports image semantic segmentation through the Python API.
+Cityscapes supports image semantic segmentation through the CLI and Python API.
 
-Expected inputs in Python:
+Expected inputs:
 
 - One or more of `train_dataset_root`, `val_dataset_root`, `test_dataset_root`
 - Images under `leftImg8bit_trainvaltest/leftImg8bit/<split>/<city>/`
@@ -171,6 +172,18 @@ Expected inputs in Python:
 - Default label suffix: `_gtFine_labelIds.png`
 
 The adapter can build either Cityscapes label-id ontologies or train-id ontologies. When using train IDs, provide train-id labels with `label_suffix="_gtFine_labelTrainIds.png"`.
+
+## SemanticKITTI
+
+SemanticKITTI supports LiDAR semantic segmentation through the CLI and Python API.
+
+Expected inputs:
+
+- `dataset_dir`: directory where SemanticKITTI has been extracted
+- `config_fname`: SemanticKITTI YAML config containing labels, colors, learning maps, and splits
+- `split`, optionally restricting the loaded samples to one split
+
+The adapter reads point clouds from `velodyne` folders and labels from `labels` folders. It can build raw label-ID ontologies and train-ID ontology translations from the SemanticKITTI YAML config.
 
 ## COCO
 
@@ -198,7 +211,7 @@ The CLI currently supports one COCO split at a time. The adapter looks for an im
 
 ## YOLO
 
-YOLO supports image object detection through the Python API. The adapter reads an Ultralytics-style dataset YAML file.
+YOLO supports image object detection through the CLI and Python API. The adapter reads an Ultralytics-style dataset YAML file.
 
 Expected YAML fields:
 
@@ -216,13 +229,10 @@ The adapter expects labels in matching `labels/<split>` directories and converts
 
 ## nuImages
 
-nuImages supports image object detection and image semantic segmentation through the Python API.
+nuImages supports image object detection and image semantic segmentation through the CLI and Python API.
 
-Expected inputs in Python:
+Expected inputs:
 
 - `dataset_dir`: nuImages root directory
 - `version`, defaulting to `v1.0-mini`
 - `split`, defaulting to `train`
-
-
-

--- a/docs/_pages/gui.md
+++ b/docs/_pages/gui.md
@@ -34,15 +34,21 @@ The following videos show the GUI workflow for the currently supported tasks:
 
 #### Image Detection GUI
 
-<iframe src="https://drive.google.com/file/d/1iNk-V3rwN9tZ2pAd_HONAkVLm3JstF00/preview" width="100%" height="420" allow="autoplay" allowfullscreen></iframe>
+<div style="position: relative; width: 100%; max-width: 720px; aspect-ratio: 16 / 9; margin-bottom: 1.5rem;">
+  <iframe src="https://www.youtube.com/embed/fRQmvGkb9KI" title="Image Detection GUI tutorial" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="position: absolute; inset: 0; width: 100%; height: 100%;"></iframe>
+</div>
 
 #### Image Segmentation GUI
 
-<iframe src="https://drive.google.com/file/d/16ixtrevvqDn6l2iuYXxHBcm4Z5IwSlOl/preview" width="100%" height="420" allow="autoplay" allowfullscreen></iframe>
+<div style="position: relative; width: 100%; max-width: 720px; aspect-ratio: 16 / 9; margin-bottom: 1.5rem;">
+  <iframe src="https://www.youtube.com/embed/B1z6mrsk8Cw" title="Image Segmentation GUI tutorial" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="position: absolute; inset: 0; width: 100%; height: 100%;"></iframe>
+</div>
 
 #### LiDAR Segmentation GUI
 
-<iframe src="https://drive.google.com/file/d/1BDT6fjLFPlG3HuHE9wWhCxwKQJ_X2PjQ/preview" width="100%" height="420" allow="autoplay" allowfullscreen></iframe>
+<div style="position: relative; width: 100%; max-width: 720px; aspect-ratio: 16 / 9; margin-bottom: 1.5rem;">
+  <iframe src="https://www.youtube.com/embed/sPIOhqD__AI" title="LiDAR Segmentation GUI tutorial" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="position: absolute; inset: 0; width: 100%; height: 100%;"></iframe>
+</div>
 
 ### 📁 Dataset Viewer Tab
 

--- a/docs/_pages/gui.md
+++ b/docs/_pages/gui.md
@@ -28,6 +28,22 @@ The GUI will open in your default web browser, typically at `http://localhost:85
 
 The GUI consists of three main tabs, each designed for specific tasks:
 
+### 🎥 GUI Tutorial Videos
+
+The following videos show the GUI workflow for the currently supported tasks:
+
+#### Image Detection GUI
+
+<iframe src="https://drive.google.com/file/d/1iNk-V3rwN9tZ2pAd_HONAkVLm3JstF00/preview" width="100%" height="420" allow="autoplay" allowfullscreen></iframe>
+
+#### Image Segmentation GUI
+
+<iframe src="https://drive.google.com/file/d/16ixtrevvqDn6l2iuYXxHBcm4Z5IwSlOl/preview" width="100%" height="420" allow="autoplay" allowfullscreen></iframe>
+
+#### LiDAR Segmentation GUI
+
+<iframe src="https://drive.google.com/file/d/1BDT6fjLFPlG3HuHE9wWhCxwKQJ_X2PjQ/preview" width="100%" height="420" allow="autoplay" allowfullscreen></iframe>
+
 ### 📁 Dataset Viewer Tab
 
 The Dataset Viewer allows you to explore and visualize your datasets before running evaluations.

--- a/docs/_pages/home.md
+++ b/docs/_pages/home.md
@@ -42,23 +42,24 @@ excerpt:
   <tr>
     <td rowspan="2">Segmentation</td>
     <td>Image</td>
-    <td>RELLIS-3D, GOOSE, RUGD, WildScenes, custom GAIA format</td>
+    <td>Cityscapes, nuImages, RELLIS-3D, GOOSE, RUGD,<br>WildScenes, GAIA, Generic</td>
     <td>PyTorch, Tensorflow</td>
   </tr>
   <tr>
     <td>LiDAR</td>
-    <td>RELLIS-3D, GOOSE, WildScenes, custom GAIA format</td>
-    <td>PyTorch (tested with <a href="https://github.com/isl-org/Open3D-ML">Open3D-ML</a>, <a href="https://github.com/open-mmlab/mmdetection3d">mmdetection3d</a>, <a href="https://github.com/dvlab-research/SphereFormer">SphereFormer</a>, and <a href="https://github.com/FengZicai/LSK3DNet">LSK3DNet</a> models)</td>  </tr>
+    <td>SemanticKITTI, RELLIS-3D, GOOSE,<br>WildScenes, GAIA, Generic</td>
+    <td>PyTorch (tested with <a href="https://github.com/isl-org/Open3D-ML">Open3D-ML</a>, <a href="https://github.com/open-mmlab/mmdetection3d">mmdetection3d</a>, <a href="https://github.com/dvlab-research/SphereFormer">SphereFormer</a>, and <a href="https://github.com/FengZicai/LSK3DNet">LSK3DNet</a> models)</td>
+  </tr>
   <tr>
     <td>Object detection</td>
     <td>Image</td>
-    <td>COCO, YOLO</td>
+    <td>COCO, YOLO, nuImages</td>
     <td>PyTorch (tested with torchvision and torchscript-exported YOLO models)</td>
   </tr>
 </tbody>
 </table>
 
-More details about the specific metrics and input/output formats required fow each framework are provided in the [Compatibility](https://jderobot.github.io/PerceptionMetrics/compatibility/) section
+More details about the specific metrics and input/output formats required for each framework are provided in the [Compatibility](https://jderobot.github.io/PerceptionMetrics/compatibility/) section
 
 # DetectionMetrics
 

--- a/docs/_pages/metrics.md
+++ b/docs/_pages/metrics.md
@@ -1,0 +1,157 @@
+---
+layout: home
+title: Metrics
+permalink: /metrics/
+
+sidebar:
+  nav: "main"
+---
+
+This page summarizes the metrics computed by PerceptionMetrics for segmentation, object detection, and model profiling. The implementation lives in `perceptionmetrics.utils.segmentation_metrics` and `perceptionmetrics.utils.detection_metrics`.
+
+## Segmentation Metrics
+
+Segmentation metrics are accumulated with `SegmentationMetricsFactory`. The factory stores a confusion matrix of shape `(n_classes, n_classes)` and updates it from integer prediction and ground-truth arrays.
+
+Supported metrics:
+
+| Metric | Meaning |
+| --- | --- |
+| `tp` | True positives |
+| `fp` | False positives |
+| `fn` | False negatives |
+| `tn` | True negatives |
+| `precision` | `TP / (TP + FP)` |
+| `recall` | `TP / (TP + FN)` |
+| `accuracy` | `(TP + TN) / (TP + FP + FN + TN)` |
+| `f1_score` | Harmonic mean of precision and recall |
+| `iou` | Intersection over Union, `TP / (TP + FP + FN)` |
+| `dice_score` | Dice coefficient, `2TP / (2TP + FP + FN)` |
+
+The metric factory supports per-class values and global values. Global metrics can be averaged as:
+
+| Average | Meaning |
+| --- | --- |
+| `macro` | Mean of per-class metric values, ignoring NaNs |
+| `micro` | Metric computed from globally summed counts |
+| `weighted` | Weighted sum of per-class values using provided weights |
+| `normalized_weighted` | Weighted mean normalized by the sum of weights |
+
+## Segmentation Output Table
+
+`get_metrics_dataframe()` returns a DataFrame with:
+
+- one column per class
+- `macro` and `micro` columns for averaged metrics
+- metric rows such as `precision`, `recall`, `iou`, and `dice_score`
+- confusion-matrix rows using class names
+
+Example shape:
+
+```text
+                 road   vegetation   sky   macro   micro
+precision        ...    ...          ...   ...     ...
+recall           ...    ...          ...   ...     ...
+iou              ...    ...          ...   ...     ...
+dice_score       ...    ...          ...   ...     ...
+road             ...    ...          ...
+vegetation       ...    ...          ...
+sky              ...    ...          ...
+```
+
+The class-name rows at the bottom represent the confusion matrix. For those rows, each column stores the count of predictions assigned to that column class for samples whose ground-truth class is the row class.
+
+## Ignored Labels
+
+Segmentation evaluation can ignore labels by passing a valid mask into the metric update. Model wrappers build this mask from `ignored_classes` in the model configuration. Ignored pixels or points are excluded before the confusion matrix is updated.
+
+## Detection Metrics
+
+Object detection metrics are accumulated with `DetectionMetricsFactory`. The factory receives ground-truth boxes, predicted boxes, labels, and confidence scores.
+
+Predictions and ground truth boxes are expected in `[x1, y1, x2, y2]` format.
+
+Supported metrics:
+
+| Metric | Meaning |
+| --- | --- |
+| `AP` | Average Precision per class using VOC-style 11-point interpolation |
+| `Precision` | Final precision value from the precision-recall curve |
+| `Recall` | Final recall value from the precision-recall curve |
+| `TP` | Number of matched true-positive detections |
+| `FP` | Number of unmatched predictions |
+| `FN` | Number of missed ground-truth objects |
+| `mAP@[0.5:0.95]` | COCO-style mean AP over IoU thresholds from `0.5` to `0.95` |
+| `AUC-PR` | Area under the overall precision-recall curve |
+
+Detection matching uses an IoU threshold. A prediction is counted as a true positive when:
+
+- it has the same class as an unmatched ground-truth box
+- its IoU with that ground-truth box is greater than or equal to the threshold
+
+Unmatched predictions become false positives. Unmatched ground-truth boxes become false negatives.
+
+## Detection Output Table
+
+`DetectionMetricsFactory.get_metrics_dataframe()` returns a DataFrame with metric names as rows and class names as columns.
+
+Example shape:
+
+```text
+                    person   vehicle   mean
+AP                  ...      ...       ...
+Precision           ...      ...       ...
+Recall              ...      ...       ...
+TP                  ...      ...       ...
+FP                  ...      ...       ...
+FN                  ...      ...       ...
+mAP@[0.5:0.95]      NaN      NaN       ...
+AUC-PR              NaN      NaN       ...
+```
+
+The `mean` column stores the mean value across valid class values. COCO-style mAP and AUC-PR are stored only in the `mean` column.
+
+## Profiling Metrics
+
+PerceptionMetrics also reports model profiling values through model `get_computational_cost()` methods. These are not dataset-quality metrics, but they are useful when comparing deployment cost.
+
+Common profiling fields:
+
+| Field | Meaning |
+| --- | --- |
+| `input_shape` | Shape of the dummy input used for profiling |
+| `n_params` | Number of model parameters |
+| `size_mb` | Model file size in megabytes when a model filename is available |
+| `inference_time_s` | Mean inference time in seconds over repeated runs |
+
+Image profiling uses a dummy image tensor. LiDAR profiling uses a dummy point cloud generated from a point-cloud range, number of points, and optional intensity channel.
+
+## Python API Examples
+
+```python
+import numpy as np
+from perceptionmetrics.utils.segmentation_metrics import SegmentationMetricsFactory
+
+metrics = SegmentationMetricsFactory(n_classes=3)
+metrics.update(
+    pred=np.array([[0, 1], [1, 2]], dtype=np.int64),
+    gt=np.array([[0, 1], [2, 2]], dtype=np.int64),
+)
+
+iou_per_class = metrics.get_iou(per_class=True)
+```
+
+```python
+from perceptionmetrics.utils.detection_metrics import DetectionMetricsFactory
+
+metrics = DetectionMetricsFactory(iou_threshold=0.5, num_classes=2)
+metrics.update(
+    gt_boxes=[[10, 10, 50, 50]],
+    gt_labels=[0],
+    pred_boxes=[[12, 12, 48, 48]],
+    pred_labels=[0],
+    pred_scores=[0.9],
+)
+
+results = metrics.compute_metrics()
+```

--- a/docs/_pages/models.md
+++ b/docs/_pages/models.md
@@ -1,0 +1,226 @@
+---
+layout: home
+title: Models
+permalink: /models/
+
+sidebar:
+  nav: "main"
+---
+
+This page summarizes the model wrappers available in PerceptionMetrics and the configuration files they expect. Model wrappers normalize framework-specific inference into the common `PerceptionModel` API used by evaluation, prediction export, and the GUI.
+
+## Support Matrix
+
+| Model wrapper | Task | Modality | Registry key | Status |
+| --- | --- | --- | --- | --- |
+| `TorchImageSegmentationModel` | Segmentation | Image | `torch_image_segmentation` | Registered |
+| `TorchLiDARSegmentationModel` | Segmentation | LiDAR | `torch_lidar_segmentation` | Registered |
+| `TorchImageDetectionModel` | Object detection | Image | `torch_image_detection` | Registered |
+| `TensorflowImageSegmentationModel` | Segmentation | Image | `tensorflow_image_segmentation` | Registered |
+
+
+
+
+## Model Ontology
+
+The model ontology maps output class names to model output indices. It uses the same basic shape as dataset ontologies:
+
+```json
+{
+  "road": {
+    "idx": 0,
+    "rgb": [128, 64, 128]
+  },
+  "vegetation": {
+    "idx": 1,
+    "rgb": [107, 142, 35]
+  }
+}
+```
+
+If model and dataset class spaces differ, provide an ontology translation during evaluation. The translation file is interpreted by the evaluation code to build a lookup table between dataset labels and model labels.
+
+## Image Segmentation Config
+
+PyTorch and TensorFlow image segmentation wrappers share a similar JSON configuration:
+
+```json
+{
+  "normalization": {
+    "mean": [0.485, 0.456, 0.406],
+    "std": [0.229, 0.224, 0.225]
+  },
+  "resize": {
+    "width": 1024,
+    "height": 512
+  },
+  "crop": {
+    "width": 1024,
+    "height": 512
+  },
+  "batch_size": 1,
+  "num_workers": 1,
+  "ignored_classes": ["unlabeled"]
+}
+```
+
+Fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `normalization` | No | Mean and standard deviation applied after converting images to float |
+| `resize` | No | Resize input image and label before inference/evaluation |
+| `crop` | No | Center crop input image and label |
+| `batch_size` | No | Evaluation batch size; defaults to `1` |
+| `num_workers` | No | PyTorch dataloader workers; defaults vary by wrapper |
+| `ignored_classes` | No | Dataset class names to exclude from metric updates |
+| `keep_aspect` | TensorFlow only | Resize while preserving aspect ratio before center crop |
+
+Expected image input shape:
+
+| Framework | Input shape | Output shape |
+| --- | --- | --- |
+| PyTorch | `(batch, channels, height, width)` | `(batch, classes, height, width)` |
+| TensorFlow | `(batch, height, width, channels)` | `(batch, height, width, classes)` |
+
+For PyTorch image segmentation, the wrapper accepts either a TorchScript file, a serialized PyTorch module, or an already loaded `torch.nn.Module` from Python.
+
+For TensorFlow image segmentation, the wrapper accepts either a SavedModel directory or a loaded TensorFlow/Keras model from Python.
+
+## LiDAR Segmentation Config
+
+`TorchLiDARSegmentationModel` supports several LiDAR model utility formats through `model_cfg["model_format"]`:
+
+```json
+{
+  "model_format": "mmdet3d",
+  "n_feats": 4,
+  "batch_size": 1
+}
+```
+
+Supported LiDAR utility formats in this branch:
+
+| `model_format` | Utility module | Notes |
+| --- | --- | --- |
+| `o3d_randlanet` | `perceptionmetrics.models.utils.o3d` | Open3D-ML RandLA-Net style inputs |
+| `o3d_kpconv` | `perceptionmetrics.models.utils.o3d` | Open3D-ML KPConv style inputs |
+| `mmdet3d` | `perceptionmetrics.models.utils.mmdet3d` | MMDetection3D style point segmentation |
+| `sphereformer` | `perceptionmetrics.models.utils.sphereformer` | Requires the SphereFormer-specific environment |
+| `lsk3dnet` | `perceptionmetrics.models.utils.lsk3dnet` | Requires the LSK3DNet-specific environment |
+
+Common fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `model_format` | Yes | LiDAR utility format |
+| `n_feats` | Usually | Number of point features, commonly `3` or `4` |
+| `batch_size` | No | Evaluation batch size |
+| `ignored_classes` | No | Dataset class names to exclude from metrics |
+
+Open3D-ML style configs may include sampler and neighborhood parameters such as `sampler`, `num_points`, `grid_size`, `num_neighbors`, and `sub_sampling_ratio`.
+
+SphereFormer style configs may include:
+
+```json
+{
+  "model_format": "sphereformer",
+  "n_feats": 4,
+  "voxel_size": [0.05, 0.05, 0.05],
+  "voxel_max": 120000,
+  "pc_range": [[-22, -17, -4], [30, 18, 13]],
+  "xyz_norm": false
+}
+```
+
+LSK3DNet style configs may include:
+
+```json
+{
+  "model_format": "lsk3dnet",
+  "n_feats": 4,
+  "min_volume_space": [-120, -120, -6],
+  "max_volume_space": [120, 120, 11]
+}
+```
+
+Additional environment setup for MMDetection3D, SphereFormer, and LSK3DNet is documented in `additional_envs/INSTRUCTIONS.md`.
+
+## Image Detection Config
+
+`TorchImageDetectionModel` supports TorchVision-style detection outputs and TorchScript-exported YOLO-style outputs. Choose the post-processing path with `model_cfg["model_format"]`.
+
+```json
+{
+  "model_format": "torchvision",
+  "resize": {
+    "min_side": 800,
+    "max_side": 1333
+  },
+  "normalization": {
+    "mean": [0.485, 0.456, 0.406],
+    "std": [0.229, 0.224, 0.225]
+  },
+  "confidence_threshold": 0.5,
+  "nms_threshold": 0.3,
+  "iou_threshold": 0.5,
+  "batch_size": 1,
+  "num_workers": 0,
+  "evaluation_step": 25
+}
+```
+
+Fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `model_format` | No | `torchvision` by default; use `yolo` for YOLO post-processing |
+| `resize` | No | Either fixed `width`/`height`, or `min_side` with optional `max_side` |
+| `crop` | No | Center crop after resize |
+| `normalization` | No | Mean and standard deviation applied to input tensors |
+| `confidence_threshold` | No | Minimum score for retained detections |
+| `nms_threshold` | YOLO only | Non-maximum suppression threshold |
+| `iou_threshold` | No | IoU threshold used by detection metrics |
+| `batch_size` | No | Evaluation batch size |
+| `num_workers` | No | Dataloader workers |
+| `evaluation_step` | No | Frequency for intermediate metric updates in GUI/evaluation callbacks |
+
+Detection predictions are expected after post-processing as dictionaries with:
+
+```text
+boxes:  [N, 4] in XYXY format
+labels: [N]
+scores: [N]
+```
+
+## Python API Examples
+
+```python
+from perceptionmetrics.models.torch_segmentation import TorchImageSegmentationModel
+
+model = TorchImageSegmentationModel(
+    model="/path/to/model.pt",
+    model_cfg="/path/to/model_cfg.json",
+    ontology_fname="/path/to/model_ontology.json",
+)
+```
+
+```python
+from perceptionmetrics.models.torch_detection import TorchImageDetectionModel
+
+model = TorchImageDetectionModel(
+    model="/path/to/detector.pt",
+    model_cfg="/path/to/detection_cfg.json",
+    ontology_fname="/path/to/model_ontology.json",
+)
+```
+
+```python
+from perceptionmetrics.models.tf_segmentation import TensorflowImageSegmentationModel
+
+model = TensorflowImageSegmentationModel(
+    model="/path/to/saved_model",
+    model_cfg="/path/to/model_cfg.json",
+    ontology_fname="/path/to/model_ontology.json",
+)
+```


### PR DESCRIPTION
This PR adds separate documentation tabs for datasets, models, and metrics in the PerceptionMetrics documentation.

## Changes

- Adds a dedicated datasets documentation page explaining the available dataset adapters and their expected usage.
- Adds a dedicated models documentation page explaining the available model wrappers and how they connect external models to PerceptionMetrics.
- Adds a dedicated metrics documentation page explaining the segmentation metrics reported by PerceptionMetrics, including precision, recall, accuracy, F1-score, IoU, Dice score, and macro/micro averaging.
- Updates the documentation navigation to include the new datasets, models, and metrics pages.

Reference Issue : #595 