### PR TITLE
LiDAR detection

### DIFF
--- a/perceptionmetrics/datasets/__init__.py
+++ b/perceptionmetrics/datasets/__init__.py
@@ -2,6 +2,7 @@ from perceptionmetrics.datasets.nuimages import (
     NuImagesDetectionDataset,
     NuImagesSegmentationDataset,
 )
+from perceptionmetrics.datasets.nuscenes import NuScenesLiDARDetectionDataset
 from perceptionmetrics.datasets.gaia import (
     GaiaImageSegmentationDataset,
     GaiaLiDARSegmentationDataset,
@@ -50,6 +51,7 @@ REGISTRY = {
     "nuimages_image_segmentation": NuImagesSegmentationDataset,
     "semantickitti_lidar_segmentation": SemanticKITTILiDARSegmentationDataset,
     "nuimages_image_detection": NuImagesDetectionDataset,
+    "nuscenes_lidar_detection": NuScenesLiDARDetectionDataset,
     "yolo_image_detection": YOLODataset,
 }
 

--- a/perceptionmetrics/datasets/__init__.py
+++ b/perceptionmetrics/datasets/__init__.py
@@ -2,7 +2,7 @@ from perceptionmetrics.datasets.nuimages import (
     NuImagesDetectionDataset,
     NuImagesSegmentationDataset,
 )
-from perceptionmetrics.datasets.nuscenes import NuScenesLiDARDetectionDataset
+from perceptionmetrics.datasets.nuScenes import NuScenesLiDARDetectionDataset
 from perceptionmetrics.datasets.gaia import (
     GaiaImageSegmentationDataset,
     GaiaLiDARSegmentationDataset,

--- a/perceptionmetrics/datasets/nuScenes.py
+++ b/perceptionmetrics/datasets/nuScenes.py
@@ -3,20 +3,10 @@ from typing import Optional, Tuple
 
 import numpy as np
 import pandas as pd
+from nuscenes.eval.common.utils import quaternion_yaw
 from nuscenes.nuscenes import NuScenes
 
 from perceptionmetrics.datasets.detection import LiDARDetectionDataset
-
-
-def quaternion_yaw(rotation) -> float:
-    """Return yaw angle from a nuScenes quaternion.
-
-    nuScenes stores rotations as quaternions in ``[w, x, y, z]`` order.
-    """
-    w, x, y, z = rotation
-    siny_cosp = 2.0 * (w * z + x * y)
-    cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
-    return float(np.arctan2(siny_cosp, cosy_cosp))
 
 
 def build_nuscenes_lidar_detection_dataset(
@@ -28,7 +18,7 @@ def build_nuscenes_lidar_detection_dataset(
     """Build a nuScenes LiDAR detection dataset index.
 
     Each row stores the LiDAR point cloud path and the corresponding
-    ``sample_data`` token used to retrieve 3D annotations.
+    sample_data token used to retrieve 3D annotations.
 
     :param dataset_dir: Path to the nuScenes dataset root directory
     :type dataset_dir: str
@@ -83,8 +73,8 @@ def build_nuscenes_lidar_detection_dataset(
 class NuScenesLiDARDetectionDataset(LiDARDetectionDataset):
     """Dataset class for nuScenes LiDAR 3D object detection.
 
-    The annotation boxes are returned as ``[x, y, z, dx, dy, dz, yaw]`` in the
-    LiDAR/global annotation convention used by nuScenes metadata.
+    The annotation boxes are returned as [x, y, z, dx, dy, dz, yaw] in the
+    LiDAR sensor frame.
 
     :param dataset_dir: Path to the nuScenes dataset root directory
     :type dataset_dir: str
@@ -137,36 +127,56 @@ class NuScenesLiDARDetectionDataset(LiDARDetectionDataset):
     def read_points(self, fname: str) -> np.ndarray:
         """Read nuScenes LiDAR points.
 
-        nuScenes LiDAR ``.bin`` files store five float32 values per point:
-        ``x, y, z, intensity, ring_index``.
+        nuScenes LiDAR .bin files store x, y, z, intensity, and ring index.
+        The ring index is dropped so the returned points match the usual
+        x, y, z, intensity format.
         """
-        return np.fromfile(fname, dtype=np.float32).reshape(-1, 5)
+        return np.fromfile(fname, dtype=np.float32).reshape(-1, 5)[:, :4]
 
     def read_annotation(self, fname: str):
         """Read 3D annotations for a nuScenes LiDAR sample-data token.
 
-        :param fname: nuScenes ``sample_data`` token
+        :param fname: nuScenes sample_data token
         :type fname: str
-        :return: Boxes in ``[x, y, z, dx, dy, dz, yaw]`` format and class IDs
+        :return: LiDAR-frame boxes in [x, y, z, dx, dy, dz, yaw] format and class IDs
         :rtype: Tuple[list, list]
         """
-        sample_data = self.nusc.get("sample_data", fname)
-        sample = self.nusc.get("sample", sample_data["sample_token"])
+        _, sample_boxes, _ = self.nusc.get_sample_data(fname)
 
         boxes = []
         labels = []
-        for annotation_token in sample["anns"]:
-            annotation = self.nusc.get("sample_annotation", annotation_token)
-            category_name = annotation["category_name"]
+        for sample_box in sample_boxes:
+            category_name = sample_box.name
             if category_name not in self.cat_to_idx:
                 continue
 
             box = [
-                *annotation["translation"],
-                *annotation["size"],
-                quaternion_yaw(annotation["rotation"]),
+                *sample_box.center,
+                *sample_box.wlh,
+                quaternion_yaw(sample_box.orientation),
             ]
             boxes.append(box)
             labels.append(self.cat_to_idx[category_name])
 
         return boxes, labels
+
+
+
+
+if __name__ == "__main__":
+    dataset = NuScenesLiDARDetectionDataset(
+        dataset_dir="examples/local/nuscenes/v1.0-mini",
+        version="v1.0-mini",
+        split="train",
+    )
+
+    print(dataset.dataset.head())
+
+    sample_token = dataset.dataset.index[0]
+    print (f"points path: {dataset.dataset.loc[sample_token, 'points']}")
+    points = dataset.read_points(dataset.dataset.loc[sample_token, "points"])
+    boxes, labels = dataset.read_annotation(dataset.dataset.loc[sample_token, "annotation"])
+    print (f"Sample token: {sample_token}")
+    print(f"Points shape: {points.shape}")
+    print(f"Boxes: {len(boxes)}, Labels: {len(labels)}")
+    print (f"ontology: {dataset.ontology}")

--- a/perceptionmetrics/datasets/nuscenes.py
+++ b/perceptionmetrics/datasets/nuscenes.py
@@ -1,0 +1,172 @@
+import os
+from typing import Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from nuscenes.nuscenes import NuScenes
+
+from perceptionmetrics.datasets.detection import LiDARDetectionDataset
+
+
+def quaternion_yaw(rotation) -> float:
+    """Return yaw angle from a nuScenes quaternion.
+
+    nuScenes stores rotations as quaternions in ``[w, x, y, z]`` order.
+    """
+    w, x, y, z = rotation
+    siny_cosp = 2.0 * (w * z + x * y)
+    cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
+    return float(np.arctan2(siny_cosp, cosy_cosp))
+
+
+def build_nuscenes_lidar_detection_dataset(
+    dataset_dir: str,
+    version: str = "v1.0-mini",
+    split: str = "train",
+    nusc_object: Optional[NuScenes] = None,
+) -> Tuple[pd.DataFrame, dict]:
+    """Build a nuScenes LiDAR detection dataset index.
+
+    Each row stores the LiDAR point cloud path and the corresponding
+    ``sample_data`` token used to retrieve 3D annotations.
+
+    :param dataset_dir: Path to the nuScenes dataset root directory
+    :type dataset_dir: str
+    :param version: nuScenes dataset version, defaults to "v1.0-mini"
+    :type version: str
+    :param split: Dataset split to assign to the indexed samples
+    :type split: str
+    :param nusc_object: Optional pre-initialized NuScenes object
+    :type nusc_object: Optional[NuScenes]
+    :return: Dataset DataFrame and ontology dictionary
+    :rtype: Tuple[pd.DataFrame, dict]
+    """
+    dataset_dir = os.path.abspath(dataset_dir)
+    assert os.path.isdir(
+        dataset_dir
+    ), f"Dataset directory {dataset_dir} does not exist."
+
+    nusc = (
+        nusc_object
+        if nusc_object
+        else NuScenes(version=version, dataroot=dataset_dir, verbose=False)
+    )
+
+    ontology = {
+        category["name"]: {"idx": idx + 1, "rgb": [0, 0, 0]}
+        for idx, category in enumerate(nusc.category)
+    }
+
+    rows = []
+    sample_names = []
+    for sample in nusc.sample:
+        lidar_token = sample["data"].get("LIDAR_TOP")
+        if lidar_token is None:
+            continue
+
+        sample_data = nusc.get("sample_data", lidar_token)
+        rows.append(
+            {
+                "points": os.path.join(dataset_dir, sample_data["filename"]),
+                "annotation": lidar_token,
+                "split": split,
+            }
+        )
+        sample_names.append(sample["token"])
+
+    dataset = pd.DataFrame(rows, index=sample_names)
+    dataset.attrs = {"ontology": ontology}
+
+    return dataset, ontology
+
+
+class NuScenesLiDARDetectionDataset(LiDARDetectionDataset):
+    """Dataset class for nuScenes LiDAR 3D object detection.
+
+    The annotation boxes are returned as ``[x, y, z, dx, dy, dz, yaw]`` in the
+    LiDAR/global annotation convention used by nuScenes metadata.
+
+    :param dataset_dir: Path to the nuScenes dataset root directory
+    :type dataset_dir: str
+    :param version: nuScenes dataset version, defaults to "v1.0-mini"
+    :type version: str
+    :param split: Dataset split to assign to the indexed samples
+    :type split: str
+    """
+
+    def __init__(
+        self,
+        dataset_dir: str,
+        version: str = "v1.0-mini",
+        split: str = "train",
+    ):
+        dataset_dir = os.path.abspath(dataset_dir)
+        assert os.path.isdir(
+            dataset_dir
+        ), f"Dataset directory {dataset_dir} does not exist."
+
+        self.nusc = NuScenes(version=version, dataroot=dataset_dir, verbose=False)
+        dataset, ontology = build_nuscenes_lidar_detection_dataset(
+            dataset_dir=dataset_dir,
+            version=version,
+            split=split,
+            nusc_object=self.nusc,
+        )
+        self.cat_to_idx = {
+            category_name: class_data["idx"]
+            for category_name, class_data in ontology.items()
+        }
+
+        super().__init__(
+            dataset=dataset,
+            dataset_dir=dataset_dir,
+            ontology=ontology,
+            is_kitti_format=False,
+        )
+
+    def make_fname_global(self):
+        """Make point cloud paths absolute while keeping annotation tokens intact."""
+        if self.dataset_dir is not None:
+            self.dataset["points"] = self.dataset["points"].apply(
+                lambda x: os.path.join(self.dataset_dir, x)
+                if x is not None and not os.path.isabs(x)
+                else x
+            )
+            self.dataset_dir = None
+
+    def read_points(self, fname: str) -> np.ndarray:
+        """Read nuScenes LiDAR points.
+
+        nuScenes LiDAR ``.bin`` files store five float32 values per point:
+        ``x, y, z, intensity, ring_index``.
+        """
+        return np.fromfile(fname, dtype=np.float32).reshape(-1, 5)
+
+    def read_annotation(self, fname: str):
+        """Read 3D annotations for a nuScenes LiDAR sample-data token.
+
+        :param fname: nuScenes ``sample_data`` token
+        :type fname: str
+        :return: Boxes in ``[x, y, z, dx, dy, dz, yaw]`` format and class IDs
+        :rtype: Tuple[list, list]
+        """
+        sample_data = self.nusc.get("sample_data", fname)
+        sample = self.nusc.get("sample", sample_data["sample_token"])
+
+        boxes = []
+        labels = []
+        for annotation_token in sample["anns"]:
+            annotation = self.nusc.get("sample_annotation", annotation_token)
+            category_name = annotation["category_name"]
+            if category_name not in self.cat_to_idx:
+                continue
+
+            box = [
+                *annotation["translation"],
+                *annotation["size"],
+                quaternion_yaw(annotation["rotation"]),
+            ]
+            boxes.append(box)
+            labels.append(self.cat_to_idx[category_name])
+
+        return boxes, labels

--- a/perceptionmetrics/models/__init__.py
+++ b/perceptionmetrics/models/__init__.py
@@ -12,9 +12,13 @@ except ImportError:
     print("Torch not available")
 
 try:
-    from perceptionmetrics.models.torch_detection import TorchImageDetectionModel
+    from perceptionmetrics.models.torch_detection import (
+        TorchImageDetectionModel,
+        TorchLiDARDetectionModel,
+    )
 
     REGISTRY["torch_image_detection"] = TorchImageDetectionModel
+    REGISTRY["torch_lidar_detection"] = TorchLiDARDetectionModel
 except ImportError:
     print("Torch detection not available")
 

--- a/perceptionmetrics/models/torch_detection.py
+++ b/perceptionmetrics/models/torch_detection.py
@@ -222,23 +222,20 @@ class LiDARDetectionTorchDataset(Dataset):
     """Dataset wrapper for LiDAR detection PyTorch models.
 
     This wrapper keeps the expected 3D box representation explicit:
-    boxes are stored as ``[x, y, z, dx, dy, dz, yaw]`` where ``x, y, z`` is the
-    box center in the LiDAR frame, ``dx, dy, dz`` are dimensions, and ``yaw`` is
+    boxes are stored as [x, y, z, dx, dy, dz, yaw] where x, y, z is the
+    box center in the LiDAR frame, dx, dy, dz are dimensions, and yaw is
     the heading angle.
 
     :param dataset: LiDAR detection dataset
     :type dataset: LiDARDetectionDataset
     :param splits: Splits to be used from the dataset, defaults to ["test"]
     :type splits: List[str], optional
-    :param has_intensity: Whether point cloud files contain intensity, defaults to True
-    :type has_intensity: bool
     """
 
     def __init__(
         self,
         dataset: detection_dataset.LiDARDetectionDataset,
         splits: List[str] = ["test"],
-        has_intensity: bool = True,
     ):
         self.dataset = copy(dataset)
         self.dataset._validate_splits(splits)
@@ -246,7 +243,6 @@ class LiDARDetectionTorchDataset(Dataset):
             self.dataset.dataset["split"].isin(splits)
         ]
         self.dataset.make_fname_global()
-        self.has_intensity = has_intensity
 
     def __len__(self):
         return len(self.dataset.dataset)
@@ -258,8 +254,10 @@ class LiDARDetectionTorchDataset(Dataset):
         points_path = row["points"]
         annotation_path = row["annotation"]
 
-        points = self.read_points(points_path)
-        boxes_3d, labels = self.read_annotation(annotation_path)
+        points = self.dataset.read_points(points_path)
+        boxes_3d, labels = self.dataset.read_annotation(annotation_path)
+        boxes_3d = np.asarray(boxes_3d, dtype=np.float32).reshape(-1, 7)
+        labels = np.asarray(labels, dtype=np.int64)
 
         target = {
             "boxes_3d": torch.as_tensor(boxes_3d, dtype=torch.float32),
@@ -267,66 +265,6 @@ class LiDARDetectionTorchDataset(Dataset):
         }
 
         return self.dataset.dataset.index[idx], torch.as_tensor(points), target
-
-    def read_points(self, points_path: str) -> np.ndarray:
-        """Read a LiDAR point cloud for detection.
-
-        If the dataset implements ``read_points``, that implementation is used.
-        Otherwise, files are read as SemanticKITTI/KITTI-style float32 ``.bin``.
-        """
-        if hasattr(self.dataset, "read_points"):
-            return self.dataset.read_points(points_path)
-
-        point_dim = 4 if self.has_intensity else 3
-        return np.fromfile(points_path, dtype=np.float32).reshape(-1, point_dim)
-
-    def read_annotation(self, annotation_path: str) -> Tuple[np.ndarray, np.ndarray]:
-        """Read and normalize 3D detection annotations."""
-        annotations = self.dataset.read_annotation(annotation_path)
-        return normalize_lidar_detection_annotations(annotations)
-
-
-def normalize_lidar_detection_annotations(annotations) -> Tuple[np.ndarray, np.ndarray]:
-    """Normalize LiDAR detection annotations to boxes and labels arrays.
-
-    Accepted forms:
-    - ``(boxes_3d, labels)``
-    - list of dicts containing ``bbox_3d``/``box_3d`` and ``category_id``/``label``
-    - list of dicts containing ``translation``, ``size``, ``yaw`` and label fields
-
-    The normalized box format is ``[x, y, z, dx, dy, dz, yaw]``.
-    """
-    if isinstance(annotations, tuple) and len(annotations) == 2:
-        boxes_3d, labels = annotations
-        return (
-            np.asarray(boxes_3d, dtype=np.float32).reshape(-1, 7),
-            np.asarray(labels, dtype=np.int64),
-        )
-
-    boxes_3d = []
-    labels = []
-    for annotation in annotations:
-        if "bbox_3d" in annotation:
-            box_3d = annotation["bbox_3d"]
-        elif "box_3d" in annotation:
-            box_3d = annotation["box_3d"]
-        else:
-            translation = annotation["translation"]
-            size = annotation["size"]
-            yaw = annotation.get("yaw", annotation.get("rotation_y", 0.0))
-            box_3d = [*translation, *size, yaw]
-
-        label = annotation.get("category_id", annotation.get("label"))
-        boxes_3d.append(box_3d)
-        labels.append(label)
-
-    boxes_3d = (
-        np.asarray(boxes_3d, dtype=np.float32).reshape(-1, 7)
-        if boxes_3d
-        else np.zeros((0, 7), dtype=np.float32)
-    )
-    labels = np.asarray(labels, dtype=np.int64)
-    return boxes_3d, labels
 
 
 class TorchImageDetectionModel(detection_model.ImageDetectionModel):
@@ -822,9 +760,9 @@ class TorchLiDARDetectionModel(detection_model.LiDARDetectionModel):
     The intended prediction format is based on common 3D detection toolkits such
     as MMDetection3D and nuScenes-style boxes:
 
-    ``boxes_3d``: ``[N, 7]`` tensor/array with ``[x, y, z, dx, dy, dz, yaw]``
-    ``labels``: ``[N]`` class indices
-    ``scores``: ``[N]`` confidence scores
+    boxes_3d: [N, 7] tensor/array with [x, y, z, dx, dy, dz, yaw]
+    labels: [N] class indices
+    scores: [N] confidence scores
 
     Actual backend-specific inference and metric evaluation are intentionally
     left unwired until the LiDAR detection dataset and metric contract is
@@ -855,7 +793,6 @@ class TorchLiDARDetectionModel(detection_model.LiDARDetectionModel):
                 f"Unsupported LiDAR detection model_format: {self.model_format}"
             )
 
-        self.has_intensity = self.model_cfg.get("has_intensity", True)
         self.idx_to_class_name = {v["idx"]: k for k, v in self.ontology.items()}
 
         if isinstance(self.model, torch.nn.Module):

--- a/perceptionmetrics/models/torch_detection.py
+++ b/perceptionmetrics/models/torch_detection.py
@@ -26,6 +26,8 @@ from perceptionmetrics.utils.torch import (
     pad_to_closest_divisor,
 )
 
+AVAILABLE_MODEL_FORMATS_LIDAR_DETECTION = ["mmdet3d"]
+
 
 def data_to_device(
     data: Union[Dict[str, torch.Tensor], List[Dict[str, torch.Tensor]]],
@@ -214,6 +216,117 @@ class ImageDetectionTorchDataset(Dataset):
             image, target = self.transform(image, target)
 
         return self.dataset.dataset.index[idx], image, target
+
+
+class LiDARDetectionTorchDataset(Dataset):
+    """Dataset wrapper for LiDAR detection PyTorch models.
+
+    This wrapper keeps the expected 3D box representation explicit:
+    boxes are stored as ``[x, y, z, dx, dy, dz, yaw]`` where ``x, y, z`` is the
+    box center in the LiDAR frame, ``dx, dy, dz`` are dimensions, and ``yaw`` is
+    the heading angle.
+
+    :param dataset: LiDAR detection dataset
+    :type dataset: LiDARDetectionDataset
+    :param splits: Splits to be used from the dataset, defaults to ["test"]
+    :type splits: List[str], optional
+    :param has_intensity: Whether point cloud files contain intensity, defaults to True
+    :type has_intensity: bool
+    """
+
+    def __init__(
+        self,
+        dataset: detection_dataset.LiDARDetectionDataset,
+        splits: List[str] = ["test"],
+        has_intensity: bool = True,
+    ):
+        self.dataset = copy(dataset)
+        self.dataset._validate_splits(splits)
+        self.dataset.dataset = self.dataset.dataset[
+            self.dataset.dataset["split"].isin(splits)
+        ]
+        self.dataset.make_fname_global()
+        self.has_intensity = has_intensity
+
+    def __len__(self):
+        return len(self.dataset.dataset)
+
+    def __getitem__(
+        self, idx: int
+    ) -> Tuple[int, torch.Tensor, Dict[str, torch.Tensor]]:
+        row = self.dataset.dataset.iloc[idx]
+        points_path = row["points"]
+        annotation_path = row["annotation"]
+
+        points = self.read_points(points_path)
+        boxes_3d, labels = self.read_annotation(annotation_path)
+
+        target = {
+            "boxes_3d": torch.as_tensor(boxes_3d, dtype=torch.float32),
+            "labels": torch.as_tensor(labels, dtype=torch.int64),
+        }
+
+        return self.dataset.dataset.index[idx], torch.as_tensor(points), target
+
+    def read_points(self, points_path: str) -> np.ndarray:
+        """Read a LiDAR point cloud for detection.
+
+        If the dataset implements ``read_points``, that implementation is used.
+        Otherwise, files are read as SemanticKITTI/KITTI-style float32 ``.bin``.
+        """
+        if hasattr(self.dataset, "read_points"):
+            return self.dataset.read_points(points_path)
+
+        point_dim = 4 if self.has_intensity else 3
+        return np.fromfile(points_path, dtype=np.float32).reshape(-1, point_dim)
+
+    def read_annotation(self, annotation_path: str) -> Tuple[np.ndarray, np.ndarray]:
+        """Read and normalize 3D detection annotations."""
+        annotations = self.dataset.read_annotation(annotation_path)
+        return normalize_lidar_detection_annotations(annotations)
+
+
+def normalize_lidar_detection_annotations(annotations) -> Tuple[np.ndarray, np.ndarray]:
+    """Normalize LiDAR detection annotations to boxes and labels arrays.
+
+    Accepted forms:
+    - ``(boxes_3d, labels)``
+    - list of dicts containing ``bbox_3d``/``box_3d`` and ``category_id``/``label``
+    - list of dicts containing ``translation``, ``size``, ``yaw`` and label fields
+
+    The normalized box format is ``[x, y, z, dx, dy, dz, yaw]``.
+    """
+    if isinstance(annotations, tuple) and len(annotations) == 2:
+        boxes_3d, labels = annotations
+        return (
+            np.asarray(boxes_3d, dtype=np.float32).reshape(-1, 7),
+            np.asarray(labels, dtype=np.int64),
+        )
+
+    boxes_3d = []
+    labels = []
+    for annotation in annotations:
+        if "bbox_3d" in annotation:
+            box_3d = annotation["bbox_3d"]
+        elif "box_3d" in annotation:
+            box_3d = annotation["box_3d"]
+        else:
+            translation = annotation["translation"]
+            size = annotation["size"]
+            yaw = annotation.get("yaw", annotation.get("rotation_y", 0.0))
+            box_3d = [*translation, *size, yaw]
+
+        label = annotation.get("category_id", annotation.get("label"))
+        boxes_3d.append(box_3d)
+        labels.append(label)
+
+    boxes_3d = (
+        np.asarray(boxes_3d, dtype=np.float32).reshape(-1, 7)
+        if boxes_3d
+        else np.zeros((0, 7), dtype=np.float32)
+    )
+    labels = np.asarray(labels, dtype=np.int64)
+    return boxes_3d, labels
 
 
 class TorchImageDetectionModel(detection_model.ImageDetectionModel):
@@ -700,4 +813,113 @@ class TorchImageDetectionModel(detection_model.ImageDetectionModel):
         dummy_input = torch.randn(1, 3, *image_size).to(self.device)
         return get_computational_cost(
             self.model, dummy_input, self.model_fname, runs, warm_up_runs
+        )
+
+
+class TorchLiDARDetectionModel(detection_model.LiDARDetectionModel):
+    """Skeleton for LiDAR detection models using PyTorch backends.
+
+    The intended prediction format is based on common 3D detection toolkits such
+    as MMDetection3D and nuScenes-style boxes:
+
+    ``boxes_3d``: ``[N, 7]`` tensor/array with ``[x, y, z, dx, dy, dz, yaw]``
+    ``labels``: ``[N]`` class indices
+    ``scores``: ``[N]`` confidence scores
+
+    Actual backend-specific inference and metric evaluation are intentionally
+    left unwired until the LiDAR detection dataset and metric contract is
+    finalized.
+    """
+
+    def __init__(
+        self,
+        model: Union[str, torch.nn.Module],
+        model_cfg: str,
+        ontology_fname: str,
+        device: torch.device = None,
+    ):
+        if device is None:
+            best_device, _ = get_device_info()
+            self.device = torch.device(best_device)
+        else:
+            self.device = torch.device(device)
+
+        model_fname = model if isinstance(model, str) else None
+        model_type = "native"
+
+        super().__init__(model, model_type, model_cfg, ontology_fname, model_fname)
+
+        self.model_format = self.model_cfg.get("model_format", "mmdet3d").lower()
+        if self.model_format not in AVAILABLE_MODEL_FORMATS_LIDAR_DETECTION:
+            raise ValueError(
+                f"Unsupported LiDAR detection model_format: {self.model_format}"
+            )
+
+        self.has_intensity = self.model_cfg.get("has_intensity", True)
+        self.idx_to_class_name = {v["idx"]: k for k, v in self.ontology.items()}
+
+        if isinstance(self.model, torch.nn.Module):
+            self.model = self.model.to(self.device).eval()
+
+    def predict(
+        self, points: np.ndarray, return_sample: bool = False
+    ) -> Union[Dict[str, torch.Tensor], Tuple[Dict[str, torch.Tensor], torch.Tensor]]:
+        """Perform prediction for a single LiDAR point cloud.
+
+        :param points: Point cloud array with shape [N, 3] or [N, 4]
+        :type points: np.ndarray
+        :param return_sample: Whether to return the prepared tensor
+        :type return_sample: bool
+        :return: LiDAR detection result, optionally with the input tensor
+        :rtype: Union[Dict[str, torch.Tensor], Tuple[Dict[str, torch.Tensor], torch.Tensor]]
+        """
+        sample = torch.as_tensor(points, dtype=torch.float32, device=self.device)
+        result = self.inference(sample)
+
+        if return_sample:
+            return result, sample
+        return result
+
+    def inference(self, points: Union[np.ndarray, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """Run LiDAR detection inference.
+
+        This method is a skeleton. Backend-specific MMDetection3D preparation and
+        post-processing should be added here.
+        """
+        raise NotImplementedError(
+            "TorchLiDARDetectionModel inference is not implemented yet. "
+            "Expected output format is boxes_3d [N, 7], labels [N], scores [N]."
+        )
+
+    def eval(
+        self,
+        dataset: detection_dataset.LiDARDetectionDataset,
+        split: Union[str, List[str]] = "test",
+        ontology_translation: Optional[str] = None,
+        predictions_outdir: Optional[str] = None,
+        results_per_sample: bool = False,
+        progress_callback=None,
+        metrics_callback=None,
+    ) -> pd.DataFrame:
+        """Evaluate a LiDAR detection model.
+
+        Kept as an explicit placeholder until 3D detection metrics are added.
+        """
+        raise NotImplementedError(
+            "TorchLiDARDetectionModel eval is not implemented yet. "
+            "LiDAR detection needs 3D box metrics before evaluation can be wired."
+        )
+
+    def get_computational_cost(
+        self,
+        point_cloud_size: Tuple[int, int] = (100000, 4),
+        runs: int = 30,
+        warm_up_runs: int = 5,
+    ) -> pd.DataFrame:
+        """Get computational cost for a LiDAR detection model.
+
+        This is left unwired while inference is still a skeleton.
+        """
+        raise NotImplementedError(
+            "TorchLiDARDetectionModel computational cost is not implemented yet."
         )


### PR DESCRIPTION
## Summary

This PR adds the initial WIP structure for LiDAR detection support in PerceptionMetrics.

## Changes

- Added a LiDAR detection dataset wrapper for PyTorch models.
- Added a placeholder `TorchLiDARDetectionModel` class.
- Added a `read_points()` interface to the LiDAR detection dataset base class.
- Added an initial nuScenes LiDAR detection dataset adapter.
- Reads nuScenes point clouds as `x, y, z, intensity`.
- Uses nuScenes sensor-frame boxes in `[x, y, z, dx, dy, dz, yaw]` format.

## TODO

- Wire LiDAR detection inference with a backend such as MMDetection3D.
- Finalize the model input pipeline for point cloud detection.
- Decide and implement 3D detection metrics.
- Add evaluation support for LiDAR detection models.
- Add prediction export format for 3D boxes.