### PR TITLE
Fix GUI detection colors by rendering the original image

### DIFF
--- a/tabs/tasks/image_detection/inference.py
+++ b/tabs/tasks/image_detection/inference.py
@@ -47,6 +47,23 @@ def draw_detections(image: Image, predictions: dict, label_map: Optional[dict] =
     )
 
 
+def run_image_detection_inference(model, image: Image.Image):
+    """Run model inference and draw detections on the original image.
+
+    :param model: Loaded image detection model.
+    :type model: object
+    :param image: Original RGB image uploaded by the user.
+    :type image: PIL.Image.Image
+    :return: Model predictions and the rendered detection image.
+    :rtype: tuple[dict, numpy.ndarray]
+    """
+    predictions = model.predict(image)
+    label_map = getattr(model, "idx_to_class_name", None)
+    result_img = draw_detections(image, predictions, label_map)
+
+    return predictions, result_img
+
+
 def render_image_detection_inference():
     """Render the image detection inference tab in Streamlit."""
 
@@ -75,16 +92,9 @@ def render_image_detection_inference():
         with st.spinner("Running inference..."):
             try:
                 image = Image.open(image_file).convert("RGB")
-                predictions, sample_tensor = st.session_state.detection_model.predict(
-                    image, return_sample=True
+                predictions, result_img = run_image_detection_inference(
+                    st.session_state.detection_model, image
                 )
-                from torchvision.transforms import v2 as transforms
-
-                img_to_draw = transforms.ToPILImage()(sample_tensor[0])
-                label_map = getattr(
-                    st.session_state.detection_model, "idx_to_class_name", None
-                )
-                result_img = draw_detections(img_to_draw, predictions, label_map)
 
                 st.markdown("#### Detection Results")
                 st.image(result_img, caption="Detection Results", width="stretch")

--- a/tests/test_image_detection_inference.py
+++ b/tests/test_image_detection_inference.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock, patch
+
+from PIL import Image
+
+from tabs.tasks.image_detection.inference import run_image_detection_inference
+
+
+def test_inference_draws_detections_on_original_image():
+    """Verify normalized model input is not reused as the display image."""
+    image = Image.new("RGB", (4, 4), color=(128, 64, 32))
+    predictions = {"boxes": [], "labels": [], "scores": []}
+    model = Mock()
+    model.predict.return_value = predictions
+    model.idx_to_class_name = {0: "object"}
+
+    with patch(
+        "tabs.tasks.image_detection.inference.draw_detections",
+        return_value="rendered-image",
+    ) as draw_detections:
+        result_predictions, result_image = run_image_detection_inference(model, image)
+
+    model.predict.assert_called_once_with(image)
+    draw_detections.assert_called_once_with(image, predictions, model.idx_to_class_name)
+    assert result_predictions is predictions
+    assert result_image == "rendered-image"


### PR DESCRIPTION
## What changed

The image detection tab was converting the model input tensor back to a display image. When normalization is configured, that tensor no longer contains display-ready RGB values.

This change draws the predictions on the original uploaded RGB image instead. The prediction path already maps bounding boxes back to the original image coordinates. A regression test verifies that the original image is passed to the drawing function and that the normalized sample is not requested.

## Reproduction

With a small RGB sample, the current conversion changed pixel (128, 64, 32) to (18, 23, 195).

## Checks

- Black formatting check
- pytest: 47 passed

Fixes #524